### PR TITLE
Fix elasticsearch-metrics.json URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@
  1. `wget https://raw.githubusercontent.com/inokappa/sensu-handler-metrics-elasticsearch/master/elasticsearch-metrics.rb` 
  1. `chmod 755 elasticsearch-metrics.rb`
  1. `cd /path/to/sensu/conf.d/`
- 1. `wget https://github.com/inokappa/sensu-handler-metrics-elasticsearch/blob/master/elasticsearch-metrics.json`
+ 1. `wget https://raw.githubusercontent.com/inokappa/sensu-handler-metrics-elasticsearch/master/elasticsearch-metrics.json`
  1. Please modify to suit your Elasticsearch environment this file(elasticsearch.json).
  1. Please restart sensu-server.


### PR DESCRIPTION
Fixed download URL for elasticsearch-metrics.json on README.md, because  `wget https://github.com/inokappa/sensu-handler-metrics-elasticsearch/blob/master/elasticsearch-metrics.json` will download just github's html, not expected json.
